### PR TITLE
Fix error E1208 raised by vim >=8.2.3141

### DIFF
--- a/vim/bundle/tlib/plugin/02tlib.vim
+++ b/vim/bundle/tlib/plugin/02tlib.vim
@@ -106,7 +106,7 @@ command! -nargs=1 -complete=command TBrowseOutput call tlib#cmd#BrowseOutput(<q-
 "
 " EXAMPLES: >
 "   TBrowseScriptnames 
-command! -nargs=0 -complete=command TBrowseScriptnames call
+command! -nargs=0 TBrowseScriptnames call
             \ tlib#cmd#BrowseOutputWithCallback("tlib#cmd#ParseScriptname", "scriptnames")
 
 " :display: :TTimeCommand CMD


### PR DESCRIPTION
Fix error E1208 in 02tlib.vim like https://github.com/tomtom/tlib_vim/commit/b5f9f6c83ade9b5640580bf9792a332dd453dfd0